### PR TITLE
Gome2 harvesting from last restart date

### DIFF
--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -60,7 +60,7 @@ class GOME2Harvester(GOME2Base,
                 except ValueError:
                     raise ValueError('end_date format must be yyyy-mm-dd')
             else:
-                raise ValueError('end_date is required')
+                end_date = self.convert_date_config('TODAY')
 
             if not (end_date > start_date) or (start_date == 'YESTERDAY' and end_date == 'TODAY'):  # noqa: E501
                 raise ValueError('end_date must be > start_date')

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -139,4 +139,7 @@ class GOME2Harvester(GOME2Base,
                 restart_date = '*'
         else:
             restart_date = '*'
-        return restart_date
+        if restart_date == '*':
+            return '*'
+        else:
+            return datetime.strptime(restart_date, '%Y-%m-%d')

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -7,10 +7,13 @@ from datetime import datetime, timedelta
 
 from ckan.plugins.core import implements
 
+from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.interfaces import IHarvester
-
 from ckanext.nextgeossharvest.lib.gome2_base import GOME2Base
 from ckanext.nextgeossharvest.lib.nextgeoss_base import NextGEOSSHarvester
+
+from ckan.model import Session
+from sqlalchemy import desc
 
 
 class GOME2Harvester(GOME2Base,
@@ -91,6 +94,13 @@ class GOME2Harvester(GOME2Base,
         else:
             self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
 
+        if self.get_last_harvesting_date() == '*':
+           self.start_date = self.start_date
+
+        else:
+            self.start_date = self.get_last_harvesting_date()
+            
+
         date = self.start_date
         date_strings = []
         while date < self.end_date:
@@ -104,3 +114,19 @@ class GOME2Harvester(GOME2Base,
 
     def fetch_stage(self, harvest_object):
         return True
+
+    def get_last_harvesting_date(self):
+        last_object = Session.query(HarvestObject). \
+                filter(HarvestObject.harvest_source_id == self.job.source_id,
+                    HarvestObject.import_finished != None). \
+                order_by(desc(HarvestObject.import_finished)).limit(1)  # noqa: E711, E501
+        if last_object:
+            try:
+                last_object = last_object[0]
+                restart_date = self._get_object_extra(last_object,
+                                                      'restart_date', '*')
+            except IndexError:
+                restart_date = '*'
+        else:
+            restart_date = '*'
+        return restart_date

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -96,9 +96,8 @@ class GOME2Harvester(GOME2Base,
             self.end_date = datetime.now()
 
 
-        if self.get_last_harvesting_date() == '*':
+        if self.get_last_harvesting_date() is None:
            self.start_date = self.start_date
-
         else:
             self.start_date = self.get_last_harvesting_date()
 
@@ -126,20 +125,15 @@ class GOME2Harvester(GOME2Base,
         return True
 
     def get_last_harvesting_date(self):
-        last_object = Session.query(HarvestObject). \
-                filter(HarvestObject.harvest_source_id == self.job.source_id,
-                    HarvestObject.import_finished != None). \
-                order_by(desc(HarvestObject.import_finished)).limit(1)  # noqa: E711, E501
-        if last_object:
-            try:
-                last_object = last_object[0]
+        last_object = Session.query(HarvestObject).\
+                        filter(
+                               HarvestObject.harvest_source_id == self.job.source_id,
+                               HarvestObject.import_finished != None).\
+                        order_by(desc(HarvestObject.import_finished)).\
+                        limit(1).first()
+        if last_object is not None:
                 restart_date = self._get_object_extra(last_object,
-                                                      'restart_date', '*')
-            except IndexError:
-                restart_date = '*'
-        else:
-            restart_date = '*'
-        if restart_date == '*':
-            return '*'
-        else:
+                                                  'restart_date')
             return datetime.strptime(restart_date, '%Y-%m-%d')
+        else:
+            return None

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -90,14 +90,11 @@ class GOME2Harvester(GOME2Base,
 
         end_date = self.source_config.get('end_date')
 
-        end_date = None
-
         if end_date is not None:
             self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
         else:
             self.end_date = datetime.now()
 
-        print('End Date: ' + str(self.end_date))    
 
         if self.get_last_harvesting_date() == '*':
            self.start_date = self.start_date
@@ -129,7 +126,6 @@ class GOME2Harvester(GOME2Base,
         return True
 
     def get_last_harvesting_date(self):
-        #return datetime(2018,2,16)
         last_object = Session.query(HarvestObject). \
                 filter(HarvestObject.harvest_source_id == self.job.source_id,
                     HarvestObject.import_finished != None). \

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -132,7 +132,7 @@ class GOME2Harvester(GOME2Base,
                         order_by(desc(HarvestObject.import_finished)).\
                         limit(1).first()
         if last_object is not None:
-                restart_date = self._get_object_extra(last_object,
+            restart_date = self._get_object_extra(last_object,
                                                   'restart_date')
             return datetime.strptime(restart_date, '%Y-%m-%d')
         else:

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -89,17 +89,17 @@ class GOME2Harvester(GOME2Base,
             self.start_date = datetime.strptime(start_date, '%Y-%m-%d')
 
         end_date = self.source_config.get('end_date', 'NOW')
-        if end_date in {"TODAY", "NOW"}:
-            self.end_date = self.convert_date_config(end_date)
-        else:
-            self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
-
+        self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
+        
         if self.get_last_harvesting_date() == '*':
            self.start_date = self.start_date
 
         else:
             self.start_date = self.get_last_harvesting_date()
-            
+
+        if self.end_date > self.start_date + timedelta(days=10):
+            self.end_date = self.start_date + timedelta(days=10)     
+        
 
         date = self.start_date
         date_strings = []
@@ -107,6 +107,7 @@ class GOME2Harvester(GOME2Base,
             date_strings.append(datetime.strftime(date, '%Y-%m-%d'))
             date += timedelta(days=1)
         self.date_strings = date_strings
+        print('DateList: {}'.format(str(date_strings)))
 
         ids = self._create_harvest_objects()
 
@@ -116,6 +117,7 @@ class GOME2Harvester(GOME2Base,
         return True
 
     def get_last_harvesting_date(self):
+        #return datetime(2018,2,16)
         last_object = Session.query(HarvestObject). \
                 filter(HarvestObject.harvest_source_id == self.job.source_id,
                     HarvestObject.import_finished != None). \

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -90,16 +90,20 @@ class GOME2Harvester(GOME2Base,
 
         end_date = self.source_config.get('end_date', 'NOW')
         self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
-        
+
         if self.get_last_harvesting_date() == '*':
            self.start_date = self.start_date
 
         else:
             self.start_date = self.get_last_harvesting_date()
 
+        if self.end_date > datetime.now():
+            self.end_date = datetime.now()
+
         if self.end_date > self.start_date + timedelta(days=10):
             self.end_date = self.start_date + timedelta(days=10)     
         
+         
 
         date = self.start_date
         date_strings = []

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -95,9 +95,8 @@ class GOME2Harvester(GOME2Base,
         else:
             self.end_date = datetime.now()
 
-
         if self.get_last_harvesting_date() is None:
-           self.start_date = self.start_date
+            self.start_date = self.start_date
         else:
             self.start_date = self.get_last_harvesting_date()
 
@@ -105,9 +104,7 @@ class GOME2Harvester(GOME2Base,
             self.end_date = datetime.now()
 
         if self.end_date > self.start_date + timedelta(days=10):
-            self.end_date = self.start_date + timedelta(days=10)     
-        
-         
+            self.end_date = self.start_date + timedelta(days=10)
 
         date = self.start_date
         date_strings = []
@@ -125,12 +122,11 @@ class GOME2Harvester(GOME2Base,
         return True
 
     def get_last_harvesting_date(self):
-        last_object = Session.query(HarvestObject).\
-                        filter(
-                               HarvestObject.harvest_source_id == self.job.source_id,
-                               HarvestObject.import_finished != None).\
-                        order_by(desc(HarvestObject.import_finished)).\
-                        limit(1).first()
+        last_object = Session.query(HarvestObject).filter(
+            HarvestObject.harvest_source_id == self.job.source_id,
+            HarvestObject.import_finished is not None).\
+            order_by(desc(HarvestObject.import_finished)).\
+            limit(1).first()
         if last_object is not None:
             restart_date = self._get_object_extra(last_object,
                                                   'restart_date')

--- a/ckanext/nextgeossharvest/harvesters/gome2.py
+++ b/ckanext/nextgeossharvest/harvesters/gome2.py
@@ -88,8 +88,16 @@ class GOME2Harvester(GOME2Base,
         else:
             self.start_date = datetime.strptime(start_date, '%Y-%m-%d')
 
-        end_date = self.source_config.get('end_date', 'NOW')
-        self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
+        end_date = self.source_config.get('end_date')
+
+        end_date = None
+
+        if end_date is not None:
+            self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
+        else:
+            self.end_date = datetime.now()
+
+        print('End Date: ' + str(self.end_date))    
 
         if self.get_last_harvesting_date() == '*':
            self.start_date = self.start_date

--- a/ckanext/nextgeossharvest/lib/gome2_base.py
+++ b/ckanext/nextgeossharvest/lib/gome2_base.py
@@ -23,7 +23,9 @@ class GOME2Base(HarvesterBase):
     def _create_harvest_object(self, content_dict):
 
         extras = [HOExtra(key='status',
-                          value='new')]
+                          value='new'),
+                HOExtra(key='restart_date',
+                        value=content_dict['date_string'])]
 
         # The NextGEOSS harvester flow requires content in the import stage.
         content = json.dumps(content_dict)


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply

This work was requested by @joaandrade  with description below.

> The main idea of this task is to guarantee that GOME-2 harvester:
> 
> - Will be able to recover from outages automatically
> - Can start from any starting date up to present
> 
> *Important Note:* In this harvested, the functions to check if a product was already harvested or if there is no product available to harvest in some date are already implemented (_missing_or_harvested function);
> 
> So in this harvester we need to implement:
> - The code to check the date of the last product harvested (re-use code from ESA harvester);
> - Harvest automatically from the date of the last product until NOW (cronjob launching jobs)
> - Harvest from any start date until NOW *is already implemented*
> - Limit of 10 days per job (this will guarantee a maximum of 50 datasets per job)

From the description above the development team identified the following _acceptance criteria_ for this task:
1. if no GOME2 products were harvested, then the harvester job starts harvesting from the configured _start date_;
2. if GOME2 products were harvested, then the harvester job starts harvesting from the last harvested product publish date;
3. the harvester job doesn't harvest more than 10 days;
4. the harvester job doesn't try to harvest after current day;
5. the harvester job doesn't harvest after the _end date_, if it is configured.

The criteria above were verified in the following way:
1. cron job tasks to create and run a harvest job for GOME2 every minute was setup;
2. the harvest gather and fetch stage were started and their logs collected in a file;
3. jobs adding products each minute were seen in CKAN harvest jobs list;
4. datasets for both the defined _start_ and _end_ dates were found in CKAN;
5. the correct date lists, i.e. 10 dates starting at the last date of the last job, were found in the logs of  gather stage of successive jobs.