### PR TITLE
Fix issue #103 - Food Security with Groups harvester update

### DIFF
--- a/ckanext/nextgeossharvest/harvesters/foodsecurity.py
+++ b/ckanext/nextgeossharvest/harvesters/foodsecurity.py
@@ -140,6 +140,9 @@ class FoodSecurityHarvester(OpenSearchHarvester, NextGEOSSHarvester):
             if 'groups' in config_obj:
                 if not isinstance(config_obj['groups'], list):
                     raise ValueError('groups must be like [{"name":"group-id"}]')  # noqa E501
+            for key in ['update_all']:
+                if key in config_obj and not isinstance(config_obj[key], bool):
+                    raise ValueError('{} must be boolean'.format(key))
         except ValueError as e:
             raise e
 
@@ -205,6 +208,8 @@ class FoodSecurityHarvester(OpenSearchHarvester, NextGEOSSHarvester):
 
         collection = self.source_config['collection']
 
+        update_all = self.source_config.get('update_all', False)
+
         last_product_date = (
             self._get_last_harvesting_date(harvest_job.source_id)
         )
@@ -220,7 +225,7 @@ class FoodSecurityHarvester(OpenSearchHarvester, NextGEOSSHarvester):
                                                  start_date, end_date)
         log.info('Harvesting {}'.format(harvest_url))
         for harvest_object in self._gather_(harvest_url):
-            _id = self._gather_entry(harvest_object)
+            _id = self._gather_entry(harvest_object, update_all=update_all)
             if _id:
                 ids.append(_id)
 
@@ -240,7 +245,8 @@ class FoodSecurityHarvester(OpenSearchHarvester, NextGEOSSHarvester):
                                                  start_date, end_date)
                 log.info('Harvesting {}'.format(harvest_url))
                 for harvest_object in self._gather_(harvest_url):
-                    _id = self._gather_entry(harvest_object)
+                    _id = self._gather_entry(harvest_object,
+                                             update_all=update_all)
                     if _id:
                         ids.append(_id)
             else:

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -302,7 +302,7 @@ class NextGEOSSHarvester(HarvesterBase):
         if "dataset_extra" in new_extras[0]['key']:
             new_values = eval(new_extras[0]['value'])
 
-        old_extra_keys = {old_values['key'] for old_values in old_values}
+        old_extra_keys = [old_value['key'] for old_value in old_values]
         for new_extra in new_values:
             if new_extra['key'] not in old_extra_keys:
                 old_values.append(new_extra)

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -296,12 +296,18 @@ class NextGEOSSHarvester(HarvesterBase):
         so that we can update metadata names more easily. We don't know what
         we'll get from iTag, though, so that's off the table for now.
         """
-        old_extra_keys = {old_extra['key'] for old_extra in old_extras}
-        for new_extra in new_extras:
-            if new_extra['key'] not in old_extra_keys:
-                old_extras.append(new_extra)
+        if "dataset_extra" in old_extras[0]['key']:
+            old_values = eval(old_extras[0]['value'])
 
-        return old_extras
+        if "dataset_extra" in new_extras[0]['key']:
+            new_values = eval(new_extras[0]['value'])
+
+        old_extra_keys = {old_values['key'] for old_values in old_values}
+        for new_extra in new_values:
+            if new_extra['key'] not in old_extra_keys:
+                old_values.append(new_extra)
+
+        return [{'key': 'dataset_extra', 'value': str(old_values)}]
 
     def make_provider_logger(self, filename='dataproviders_info.log'):
         """Create a logger just for provider uptimes."""

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -296,18 +296,16 @@ class NextGEOSSHarvester(HarvesterBase):
         so that we can update metadata names more easily. We don't know what
         we'll get from iTag, though, so that's off the table for now.
         """
-        if "dataset_extra" in old_extras[0]['key']:
-            old_values = eval(old_extras[0]['value'])
 
         if "dataset_extra" in new_extras[0]['key']:
             new_values = eval(new_extras[0]['value'])
 
-        old_extra_keys = [old_value['key'] for old_value in old_values]
+        old_extra_keys = [old_value['key'] for old_value in old_extras]
         for new_extra in new_values:
             if new_extra['key'] not in old_extra_keys:
-                old_values.append(new_extra)
+                old_extras.append(new_extra)
 
-        return [{'key': 'dataset_extra', 'value': str(old_values)}]
+        return [{'key': 'dataset_extra', 'value': str(old_extras)}]
 
     def make_provider_logger(self, filename='dataproviders_info.log'):
         """Create a logger just for provider uptimes."""


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Regarding [Issue #103](https://github.com/NextGeoss/ckanext-nextgeossharvest/issues/103):

- **Add feature:** Update previously harvested food security datasets with groups and extra field "is_output"

- **Bug fix:** Changed the file **nextgeoss_base.py** due to the fact the function __update_extras()_ 
was comparing the new and old key values of extras dictionaries, and only adding if the key was different. However, due to the structure of such dictionary being:

`[{'key': 'dataset_extra', 'value': str(extras_tmp)}]`

the function was only retrieving 'dataset_extra' from both dictionaries, and thus never updating any extra fields.

Comparing the harvester configuration provided in Issue #103 I noticed that there is already one field missing, 'groups', please reffer to the comments of [PR #94](https://github.com/NextGeoss/ckanext-nextgeossharvest/pull/94#discussion_r306174905)

With this additional feature of the current PR, there is also an additional configuration parameter 'update_all' that receives a boolean. Follows an example of harvest configuration:

```
{
"start_date":"2017-01-01",
"collection":"FAPAR",
"username":"nextgeoss",
"password":"nextgeoss",
"make_private":false,
"update_all":true,
"groups": [{"name":"food-security"}]
}
```

### Features:

- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes bugfix

Please [X] all the boxes above that apply
