### PR TITLE
Fix Sentinel query logic with restart date

### DIFF
--- a/ckanext/nextgeossharvest/harvesters/esa.py
+++ b/ckanext/nextgeossharvest/harvesters/esa.py
@@ -101,7 +101,11 @@ class ESAHarvester(SentinelHarvester, OpenSearchHarvester, NextGEOSSHarvester):
             restart_date = '*'
         log.debug('Restart date is {}'.format(restart_date))
 
-        start_date = self.source_config.get('start_date', restart_date)
+        if restart_date == '*':
+            start_date = self.source_config.get('start_date', restart_date)
+        else:
+            start_date = restart_date
+
         end_date = self.source_config.get('end_date', 'NOW')
         date_range = '[{} TO {}]'.format(start_date, end_date)
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Regarding Issue #106  the query logic using the restart date as been updated. The priority is now restart_date (previous job) --> start_date (harvest configuration) --> '*' (default)

### Features:

- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes bugfix

Please [X] all the boxes above that apply
