### PR TITLE
Sentinel remove field from extras

### DIFF
--- a/ckanext/nextgeossharvest/lib/esa_base.py
+++ b/ckanext/nextgeossharvest/lib/esa_base.py
@@ -471,7 +471,7 @@ class SentinelHarvester(HarvesterBase):
             old_resources = [x.as_dict() for x in self.obj.package.resources]
         else:
             old_resources = None
-        parsed_resources=parsed_content['resource']
+        parsed_resources = parsed_content['resource']
         product = self._make_product_resource(parsed_resources)
         manifest = self._make_manifest_resource(parsed_resources)
         thumbnail = self._make_thumbnail_resource(parsed_resources)

--- a/ckanext/nextgeossharvest/lib/esa_base.py
+++ b/ckanext/nextgeossharvest/lib/esa_base.py
@@ -255,6 +255,7 @@ class SentinelHarvester(HarvesterBase):
         Parse the entry content and return a dictionary using our standard
         metadata terms.
         """
+        source = self.source_config.get('source', None)
         soup = Soup(content, 'lxml')
 
         # Create an item dictionary and add metadata with normalized names.
@@ -268,47 +269,14 @@ class SentinelHarvester(HarvesterBase):
 
         item['name'] = item['identifier'].lower()
 
-        # Thumbnail, alternative and enclosure
-        enclosure = soup.find('link', rel=None)['href']
-        alternative = soup.find('link', rel='alternative')['href']
-        thumbnail = soup.find('link', rel='icon')
-
-        resources = {}
-        if enclosure.startswith('https://scihub'):
-            resources['scihub_download_url'] = enclosure
-            resources['scihub_product_url'] = alternative
-            if 's5p' not in item['name']:
-                resources['scihub_manifest_url'] = self._make_manifest_url(item, resources)
-            if thumbnail:
-                resources['scihub_thumbnail'] = thumbnail['href']
-        elif enclosure.startswith('https://sentinels'):
-            resources['noa_download_url'] = enclosure
-            resources['noa_product_url'] = alternative
-            if 's5p' not in item['name']:
-                resources['noa_manifest_url'] = self._make_manifest_url(item, resources)
-            if thumbnail:
-                resources['noa_thumbnail'] = thumbnail['href']
-            ingestion_date = soup.find('date',
-                                       {'name': 'ingestiondate'}).text
-            if '.' not in ingestion_date:
-                ingestion_date = ingestion_date.replace('Z', '.000Z')
-            ingestion_date = datetime.datetime.strptime(ingestion_date,
-                                                        '%Y-%m-%dT%H:%M:%S.%fZ')  # noqa: E501
-            expiration_date = ingestion_date + datetime.timedelta(days=30)
-            item['noa_expiration_date'] = datetime.datetime.strftime(expiration_date, '%Y-%m-%d')  # noqa: E501
-            resources['noa_expiration_date']=item['noa_expiration_date']
-        elif enclosure.startswith('https://code-de'):
-            resources['code_download_url'] = enclosure
-            resources['code_product_url'] = alternative
-            if 's5p' not in item['name']:
-                resources['code_manifest_url'] = self._make_manifest_url(item)
-            if thumbnail:
-                resources['code_thumbnail'] = thumbnail['href']
+        if source == 'esa_noa':
+            item['noa_expiration_date'] = self._get_noa_expiration_date(soup)
 
         # Convert size (298.74 MB to an integer representing bytes)
-        resources['size'] = int(float(item['size'].split(' ')[0]) * 1000000)
-        resources['identifier'] = item['identifier']
-        item['resource'] = resources
+        size = int(float(item.pop('size').split(' ')[0]) * 1000000)
+
+        item['resource'] = self._parse_resources(item, soup, source, size)
+
         # Add the collection info
         item = self._add_collection(item)
 
@@ -325,52 +293,86 @@ class SentinelHarvester(HarvesterBase):
         item['timerange_start'] = item['StartTime']
         item['timerange_end'] = item['StopTime']
 
-        # Remove from the package dictionary the metadata fields that will not be
-        # added to the database
+        # Remove from the package dictionary the metadata fields that will not
+        # be added to the database
         item.pop('Filename')
-        item.pop('size')
-
 
         return item
 
-    def _make_manifest_url(self, item, resource):
+    def _get_noa_expiration_date(self, content):
+        ingestion_date = content.find('date',
+                                      {'name': 'ingestiondate'}).text
+        if '.' not in ingestion_date:
+            ingestion_date = ingestion_date.replace('Z', '.000Z')
+        ingestion_date = datetime.datetime.strptime(ingestion_date,
+                                                    '%Y-%m-%dT%H:%M:%S.%fZ')
+        expiration_date = ingestion_date + datetime.timedelta(days=30)
+
+        return datetime.datetime.strftime(expiration_date, '%Y-%m-%d')
+
+    def _parse_resources(self, item, content, source, size):
+        resources = []
+
+        expiration_date = item.get('noa_expiration_date', None)
+        identifier = item.get('identifier', None)
+
+        # Thumbnail, alternative and enclosure
+        enclosure = content.find('link', rel=None)['href']
+        prod_resource = self._make_product_resource(source, enclosure, size,
+                                                    identifier,
+                                                    expiration_date)
+        resources.append(prod_resource)
+
+        if 's5p' not in item['name']:
+            manifest_url = self._make_manifest_url(item, source)
+            manifest_resource = self._make_manifest_resource(source,
+                                                             manifest_url,
+                                                             expiration_date)
+            resources.append(manifest_resource)
+
+        thumbnail = content.find('link', rel='icon')
+        if thumbnail:
+            thumbnail_url = thumbnail['href']
+            thumbnail_resource = self._make_thumbnail_resource(source,
+                                                               thumbnail_url,
+                                                               expiration_date)
+            resources.append(thumbnail_resource)
+
+        return resources
+
+    def _make_manifest_url(self, item, source):
         """Create the URL for manifests on SciHub, NOA, or CODE-DE."""
         if item['name'].startswith('s3'):
             manifest_file = 'xfdumanifest.xml'
         else:
             manifest_file = 'manifest.safe'
-        if resource.get('scihub_product_url'):
+
+        if source == 'esa_scihub':
             base_url = 'https://scihub.copernicus.eu/dhus/'
-        elif resource.get('noa_product_url'):
+        elif source == 'esa_noa':
             base_url = 'https://sentinels.space.noa.gr/dhus/'
-        elif resource.get('code_product_url'):
+        elif source == 'esa_code':
             base_url = 'https://code-de.org/dhus/'
 
         manifest_url = "{}odata/v1/Products('{}')/Nodes('{}')/Nodes('{}')/$value".format(base_url, item['uuid'], item['Filename'], manifest_file)  # noqa: E501
 
         return manifest_url
 
-    def _make_manifest_resource(self, item):
+    def _make_manifest_resource(self, source, url, expiration_date):
         """
         Return a manifest resource dictionary depending on the harvest source.
         """
-        if item.get('scihub_manifest_url'):
+        if source == 'esa_scihub':
             name = 'Metadata Download from SciHub'
             description = 'Download the metadata manifest from SciHub. NOTE: DOWNLOAD REQUIRES LOGIN'  # noqa: E501
-            url = item['scihub_manifest_url']
-            order = 4
             _type = 'scihub_manifest'
-        elif item.get('noa_manifest_url'):
-            name = 'Metadata Download from NOA (valid until {})'.format(item['noa_expiration_date'])  # noqa: E501'
-            description = 'Download the metadata manifest from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(item['noa_expiration_date'])  # noqa: E501'
-            url = item['noa_manifest_url']
-            order = 5
+        elif source == 'esa_noa':
+            name = 'Metadata Download from NOA (valid until {})'.format(expiration_date)  # noqa: E501
+            description = 'Download the metadata manifest from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(expiration_date)  # noqa: E501
             _type = 'noa_manifest'
-        elif item.get('code_manifest_url'):
+        elif source == 'esa_code':
             name = 'Metadata Download from CODE-DE'
             description = 'Download the metadata manifest from CODE-DE. NOTE: DOWNLOAD REQUIRES LOGIN'  # noqa: E501
-            url = item['code_manifest_url']
-            order = 6
             _type = 'code_manifest'
         else:
             return None
@@ -380,32 +382,25 @@ class SentinelHarvester(HarvesterBase):
                     'url': url,
                     'format': 'XML',
                     'mimetype': 'application/xml',
-                    'resource_type': _type,
-                    'order': order}
+                    'resource_type': _type}
 
         return manifest
 
-    def _make_thumbnail_resource(self, item):
+    def _make_thumbnail_resource(self, source, url, expiration_date):
         """
         Return a thumbnail resource dictionary depending on the harvest source.
         """
-        if item.get('scihub_thumbnail'):
+        if source == 'esa_scihub':
             name = 'Thumbnail Download from SciHub'
             description = 'Download the thumbnail from SciHub. NOTE: DOWNLOAD REQUIRES LOGIN'  # noqa: E501
-            url = item['scihub_thumbnail']
-            order = 7
             _type = 'scihub_thumbnail'
-        elif item.get('noa_thumbnail'):
-            name = 'Thumbnail Download from NOA (valid until {})'.format(item['noa_expiration_date'])  # noqa: E501
-            description = 'Download the thumbnail from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(item['noa_expiration_date'])  # noqa: E501
-            url = item['noa_thumbnail']
-            order = 8
+        elif source == 'esa_noa':
+            name = 'Thumbnail Download from NOA (valid until {})'.format(expiration_date)  # noqa: E501
+            description = 'Download the thumbnail from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(expiration_date)  # noqa: E501
             _type = 'noa_thumbnail'
-        elif item.get('code_thumbnail'):
+        elif source == 'esa_code':
             name = 'Thumbnail Download from CODE-DE'
             description = 'Download the thumbnail from CODE-DE.'  # noqa: E501
-            url = item['code_thumbnail']
-            order = 9
             _type = 'code_thumbnail'
         else:
             return None
@@ -415,53 +410,42 @@ class SentinelHarvester(HarvesterBase):
                      'url': url,
                      'format': 'JPEG',
                      'mimetype': 'image/jpeg',
-                     'resource_type': _type,
-                     'order': order}
+                     'resource_type': _type}
 
         return thumbnail
 
-    def _make_product_resource(self, item):
+    def _make_product_resource(self, source, url, size,
+                               identifier, expiration_date):
         """
         Return a product resource dictionary depending on the harvest source.
         """
-        if item.get('scihub_download_url'):
+        if source == 'esa_scihub':
             name = 'Product Download from SciHub'
             description = 'Download the product from SciHub. NOTE: DOWNLOAD REQUIRES LOGIN'  # noqa: E501
-            url = item['scihub_download_url']
-            order = 1
             _type = 'scihub_product'
-        elif item.get('noa_download_url'):
-            name = 'Product Download from NOA (valid until {})'.format(item['noa_expiration_date'])  # noqa: E501'
-            description = 'Download the product from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(item['noa_expiration_date'])  # noqa: E501
-            url = item['noa_download_url']
-            order = 2
+        elif source == 'esa_noa':
+            name = 'Product Download from NOA (valid until {})'.format(expiration_date)  # noqa: E501'
+            description = 'Download the product from NOA (valid until {}). NOTE: DOWNLOAD REQUIRES LOGIN'.format(expiration_date)  # noqa: E501
             _type = 'noa_product'
-        elif item.get('code_download_url'):
+        elif source == 'esa_code':
             name = 'Product Download from CODE-DE'
             description = 'Download the product from CODE-DE. NOTE: DOWNLOAD REQUIRES LOGIN'  # noqa: E501
-            url = item['code_download_url']
-            order = 3
             _type = 'code_product'
-        size = item['size']
 
-        if 's5p' not in item['identifier']:
-            product = {'name': name,
-                       'description': description,
-                       'url': url,
-                       'format': 'SAFE',
-                       'mimetype': 'application/zip',
-                       'size': size,
-                       'resource_type': _type,
-                       'order': order}
+        if 's5p' not in identifier:
+            file_type = 'SAFE'
+            mime_type = 'application/zip'
         else:
-            product = {'name': name,
-                       'description': description,
-                       'url': url,
-                       'format': 'netCDF',
-                       'mimetype': 'application/x-netcdf',
-                       'size': size,
-                       'resource_type': _type,
-                       'order': order}
+            file_type = 'netCDF'
+            mime_type = 'application/x-netcdf'
+
+        product = {'name': name,
+                   'description': description,
+                   'url': url,
+                   'format': file_type,
+                   'mimetype': mime_type,
+                   'size': size,
+                   'resource_type': _type}
 
         return product
 
@@ -472,14 +456,8 @@ class SentinelHarvester(HarvesterBase):
         else:
             old_resources = None
         parsed_resources = parsed_content['resource']
-        product = self._make_product_resource(parsed_resources)
-        manifest = self._make_manifest_resource(parsed_resources)
-        thumbnail = self._make_thumbnail_resource(parsed_resources)
+        new_resources = [x for x in parsed_resources if x]
 
-        if manifest is None:
-            new_resources = [x for x in [product, thumbnail] if x]
-        else:
-            new_resources = [x for x in [product, manifest, thumbnail] if x]
         if not old_resources:
             resources = new_resources
         else:
@@ -488,11 +466,10 @@ class SentinelHarvester(HarvesterBase):
             resources = []
             for old in old_resources:
                 old_type = old.get('resource_type')
-                order = old.get('order')
-                if old_type not in new_resource_types and order:
+                if old_type not in new_resource_types:
                     resources.append(old)
             resources += new_resources
 
-            resources.sort(key=lambda x: x['order'])
+        resources.sort(key=lambda x: x['name'])
 
         return resources


### PR DESCRIPTION
Fixes #

### Proposed fixes:


### Features:

Regarding issue #124 :
- The fields `Filename` and `size` are still parsed, due to the fact that they are used to extract other required fields. However, they are not sent as dataset metadata
    * `psn` is retrieved from `Filename`
    * `size` is used in the resource metadata
- `thumbnail` and `summary` are completely purged from the code
- the fields `*_url` and `*_thumbnail` are fed to the package resource creation function via the package field 'resource', which is ignored / skipped when creating [extra fields](https://github.com/NextGeoss/ckanext-nextgeossharvest/blob/c0bb3a7dfe372fa2df38a10c7cf17d6c83014ed7/ckanext/nextgeossharvest/lib/nextgeoss_base.py#L269).


- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
