### PR TITLE
Issue146 fix _update_extras

### DIFF
--- a/ckanext/nextgeossharvest/harvesters/esa.py
+++ b/ckanext/nextgeossharvest/harvesters/esa.py
@@ -58,7 +58,7 @@ class ESAHarvester(SentinelHarvester, OpenSearchHarvester, NextGEOSSHarvester):
                 timeout = config_obj['timeout']
                 if not isinstance(timeout, int) and not timeout > 0:
                     raise ValueError('timeout must be a positive integer')
-            for key in ['update_all', 'skip_raw']:
+            for key in ['update_all', 'skip_raw', 'multiple_sources']:
                 if key in config_obj:
                     if not isinstance(config_obj[key], bool):
                         raise ValueError('{} must be boolean'.format(key))

--- a/ckanext/nextgeossharvest/harvesters/esa.py
+++ b/ckanext/nextgeossharvest/harvesters/esa.py
@@ -59,9 +59,8 @@ class ESAHarvester(SentinelHarvester, OpenSearchHarvester, NextGEOSSHarvester):
                 if not isinstance(timeout, int) and not timeout > 0:
                     raise ValueError('timeout must be a positive integer')
             for key in ['update_all', 'skip_raw', 'multiple_sources']:
-                if key in config_obj:
-                    if not isinstance(config_obj[key], bool):
-                        raise ValueError('{} must be boolean'.format(key))
+                if key in config_obj and not isinstance(config_obj[key], bool):
+                    raise ValueError('{} must be boolean'.format(key))
             if type(config_obj.get('make_private', False)) != bool:
                 raise ValueError('make_private must be true or false')
 
@@ -174,7 +173,6 @@ class ESAHarvester(SentinelHarvester, OpenSearchHarvester, NextGEOSSHarvester):
         self.provider = source
 
         # This can be a hook
-        print harvest_url
         ids = self._crawl_results(harvest_url, limit, timeout, username,
                                   password)
         # This can be a hook

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -5,27 +5,23 @@ import json
 import logging
 import os
 import uuid
-from string import Template
 from datetime import datetime
+from string import Template
+
 import requests
 from requests.auth import HTTPBasicAuth
-import requests_ftp
 from requests.exceptions import ConnectTimeout, ReadTimeout
+from sqlalchemy.sql import bindparam, update
 
-from sqlalchemy.sql import update, bindparam
+import requests_ftp
 import shapely.wkt
-from shapely.errors import ReadingError, WKTReadingError
-
+from ckan import logic, model
 from ckan import plugins as p
-from ckan import model
 from ckan.common import config
-from ckan.model import Session
-from ckan.model import Package
-from ckan import logic
 from ckan.lib.navl.validators import not_empty
-
+from ckan.model import Package, Session
 from ckanext.harvest.harvesters.base import HarvesterBase
-
+from shapely.errors import ReadingError, WKTReadingError
 
 log = logging.getLogger(__name__)
 
@@ -303,14 +299,12 @@ class NextGEOSSHarvester(HarvesterBase):
         print("New-extras: {}".format(new_extras))
         if extend_extras:
 
-            if "dataset_extra" in old_extras[0]['key']:
-                old_values = eval(old_extras[0]['value'])
-
             if "dataset_extra" in new_extras[0]['key']:
                 new_values = eval(new_extras[0]['value'])
                 new_extra_keys = [new_value['key'] for new_value in new_values]
-
-            for old_extra in old_values:
+            print("New-extras keys: {}".format(new_extra_keys))
+            for old_extra in old_extras:
+                print(old_extra['key'])
                 if old_extra['key'] not in new_extra_keys:
                     new_values.append(old_extra)
 

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -285,7 +285,9 @@ class NextGEOSSHarvester(HarvesterBase):
 
     def _update_extras(self, old_extras, new_extras):
         """
-        Replace the old extras with the new extras from the harvester.
+        Replace the old extras with the new extras from the harvester,
+        or extend the new extras with the different fields from
+        old_extras
         """
 
         ignore_list = [

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -292,17 +292,29 @@ class NextGEOSSHarvester(HarvesterBase):
         Replace the old extras with the new extras from the harvester.
         """
 
-        print(new_extras)
-        if "dataset_extra" in new_extras[0]['key']:
-            new_values = eval(new_extras[0]['value'])
-        print(new_values)
+        # Robustness protection for harvesters that do not save configuration
+        # into self.source_config
+        extend_extras = False
+        if hasattr(self, 'source_config') and hasattr(self.source_config,
+                                                      'multiple_sources'):
+            extend_extras = self.source_config.get('multiple_sources', False)
 
-        if True:
-            # placeholder for product extras update,
-            # that only have 1 data source
-            return new_extras
-        else:
+        if extend_extras:
+
+            if "dataset_extra" in old_extras[0]['key']:
+                old_values = eval(old_extras[0]['value'])
+
+            if "dataset_extra" in new_extras[0]['key']:
+                new_values = eval(new_extras[0]['value'])
+                new_extra_keys = [new_value['key'] for new_value in new_values]
+
+            for old_extra in old_values:
+                if old_extra['key'] not in new_extra_keys:
+                    new_values.append(old_extra)
+
             return [{'key': 'dataset_extra', 'value': str(new_values)}]
+        else:
+            return new_extras
 
     def make_provider_logger(self, filename='dataproviders_info.log'):
         """Create a logger just for provider uptimes."""

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -292,10 +292,17 @@ class NextGEOSSHarvester(HarvesterBase):
         Replace the old extras with the new extras from the harvester.
         """
 
+        print(new_extras)
         if "dataset_extra" in new_extras[0]['key']:
             new_values = eval(new_extras[0]['value'])
+        print(new_values)
 
-        return [{'key': 'dataset_extra', 'value': str(new_values)}]
+        if True:
+            # placeholder for product extras update,
+            # that only have 1 data source
+            return new_extras
+        else:
+            return [{'key': 'dataset_extra', 'value': str(new_values)}]
 
     def make_provider_logger(self, filename='dataproviders_info.log'):
         """Create a logger just for provider uptimes."""

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -299,6 +299,8 @@ class NextGEOSSHarvester(HarvesterBase):
                                                       'multiple_sources'):
             extend_extras = self.source_config.get('multiple_sources', False)
 
+        print("Old-extras: {}".format(old_extras))
+        print("New-extras: {}".format(new_extras))
         if extend_extras:
 
             if "dataset_extra" in old_extras[0]['key']:

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -289,23 +289,13 @@ class NextGEOSSHarvester(HarvesterBase):
 
     def _update_extras(self, old_extras, new_extras):
         """
-        Add new extras from the harvester, but preserve existing extras
-        so that we don't lose any from iTag.
-
-        In the future, we should restrict the filter to only extras from iTag
-        so that we can update metadata names more easily. We don't know what
-        we'll get from iTag, though, so that's off the table for now.
+        Replace the old extras with the new extras from the harvester.
         """
 
         if "dataset_extra" in new_extras[0]['key']:
             new_values = eval(new_extras[0]['value'])
 
-        old_extra_keys = [old_value['key'] for old_value in old_extras]
-        for new_extra in new_values:
-            if new_extra['key'] not in old_extra_keys:
-                old_extras.append(new_extra)
-
-        return [{'key': 'dataset_extra', 'value': str(old_extras)}]
+        return [{'key': 'dataset_extra', 'value': str(new_values)}]
 
     def make_provider_logger(self, filename='dataproviders_info.log'):
         """Create a logger just for provider uptimes."""

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
### Features:
Update of the function for dataset metadata extras fields, the approach taken was:

- For the datasets that only have 1 data provider, the approach is to replace entirely the old extras dictionary with the new dictionary collected. Which will be already "cleaned" of the unnecessary fields. Thus, not requiring explicit removal of the fields (done during the content parsing).

- For the datasets that have 2 or more data providers (in our current situation, we only have sentinel products), the approach will have to be slightly different. In this case, we will expand the new dictionary with fields from the old dictionary, if the key does not belong to the list (#124 and #126 ). So opposed to the first scenario, the removal is explicit, which is necessary due to the fact that different data providers might have different fields.

To complement the second approach, a new field has been added to Sentinel Harvester ("multiple_sources"), a new issue #197 has been opened to track this update. Which allows to track if the datasets collected by that harvester are also expanded by other harvesters.

Although it will not impact the normal behavior of the harvester, the [ignore_list](https://github.com/NextGeoss/ckanext-nextgeossharvest/blob/4d796cb7d1a076f444d2bd51c8a2b26f3ff57aa7/ckanext/nextgeossharvest/lib/nextgeoss_base.py#L293) and the [second condition](https://github.com/NextGeoss/ckanext-nextgeossharvest/blob/4d796cb7d1a076f444d2bd51c8a2b26f3ff57aa7/ckanext/nextgeossharvest/lib/nextgeoss_base.py#L330) can be safely removed once all the Sentinel products currently in the datahub have been updated.


- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
