### PR TITLE
Feature/naming convention

### DIFF
--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -266,7 +266,7 @@ class NextGEOSSHarvester(HarvesterBase):
     def _get_extras(self, parsed_content):
         """Return a list of CKAN extras."""
         skip = {'id', 'title', 'tags', 'status', 'notes', 'name', 'resource', 'groups'}  # noqa: E501
-        extras_tmp = [{'key': stringcase.snakecase(key.lower()), 'value': value}
+        extras_tmp = [{'key': self.convert_to_clean_snakecase(key), 'value': value}
                       for key, value in parsed_content.items()
                       if key not in skip]
         extras = [{'key': 'dataset_extra', 'value': str(extras_tmp)}]
@@ -329,7 +329,7 @@ class NextGEOSSHarvester(HarvesterBase):
             for old_extra in old_extras:
                 if ((old_extra['key'] not in new_extra_keys) and 
                     (old_extra['key'] not in ignore_list)):
-                    old_extra['key'] = stringcase.snakecase(old_extra['key'].lower())
+                    old_extra['key'] = self.convert_to_clean_snakecase(old_extra['key'])
                     new_values.append(old_extra)
             return [{'key': 'dataset_extra', 'value': str(new_values)}]
         else:
@@ -425,6 +425,10 @@ class NextGEOSSHarvester(HarvesterBase):
         self.provider_logger.info(log_message.format(provider, timestamp,
                                                      status_code, elapsed))
         return size
+
+    def convert_to_clean_snakecase(self, extra_key):
+        clean_extra_key = re.sub('[^0-9a-zA-Z]+', '_', stringcase.snakecase(extra_key)).strip('_')
+        return clean_extra_key
 
     def import_stage(self, harvest_object):
         log = logging.getLogger(__name__ + '.import')

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime
 from string import Template
 import stringcase
+import re
 
 import requests
 from requests.auth import HTTPBasicAuth

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -265,7 +265,7 @@ class NextGEOSSHarvester(HarvesterBase):
     def _get_extras(self, parsed_content):
         """Return a list of CKAN extras."""
         skip = {'id', 'title', 'tags', 'status', 'notes', 'name', 'resource', 'groups'}  # noqa: E501
-        extras_tmp = [{'key': key, 'value': value}
+        extras_tmp = [{'key': stringcase.snakecase(key.lower()), 'value': value}
                       for key, value in parsed_content.items()
                       if key not in skip]
         extras = [{'key': 'dataset_extra', 'value': str(extras_tmp)}]
@@ -328,6 +328,7 @@ class NextGEOSSHarvester(HarvesterBase):
             for old_extra in old_extras:
                 if ((old_extra['key'] not in new_extra_keys) and 
                     (old_extra['key'] not in ignore_list)):
+                    old_extra['key'] = stringcase.snakecase(old_extra['key'].lower())
                     new_values.append(old_extra)
             return [{'key': 'dataset_extra', 'value': str(new_values)}]
         else:

--- a/ckanext/nextgeossharvest/lib/nextgeoss_base.py
+++ b/ckanext/nextgeossharvest/lib/nextgeoss_base.py
@@ -7,6 +7,7 @@ import os
 import uuid
 from datetime import datetime
 from string import Template
+import stringcase
 
 import requests
 from requests.auth import HTTPBasicAuth

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests-ftp
 enum34
 python-dateutil
 monthdelta
+stringcase


### PR DESCRIPTION
Fixes #

### Proposed fixes:
To use the snakecase naming convention in oder to standardize all the metadata field names in the NextGEOSS Catalogue.
e.g. Point of Contact -> point_of_contact

### Features:
Function **convert_to_clean_snakecase**  added to the nextgeoss_base.py. This function converts all the extra field keys to the snacase format.

- [X] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
