### PR TITLE
Feature/vito os harvester

### DIFF
--- a/ckanext/nextgeossharvest/collection_description/vito_collection.py
+++ b/ckanext/nextgeossharvest/collection_description/vito_collection.py
@@ -1,0 +1,3192 @@
+COLLECTION = {
+    "SENTINEL_2_TOC_V2": {
+        "collection_name": "Sentinel-2 TOC V2",
+        "collection_description": "L2A atmospheric corrected Top-Of-Canopy (TOC) products V2, generated using the Sen2COR processing tool.",
+        "collection_search": "urn:eop:VITO:TERRASCOPE_S2_TOC_V2",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B05_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B05_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                },
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B05_20M"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": " TOC-B01_60M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B01_60M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                },
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B01_60M"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B06_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B06_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                },
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B06_20M"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B11_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B11_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                },
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B11_20M"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B07_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B07_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B07_20M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B8A_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B8A_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                },
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B8A_20M"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B03_10M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B03_10M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B03_10M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B04_10M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B04_10M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B04_10M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B12_20M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B12_20M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B12_20M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B08_10M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B08_10M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B08_10M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "TOC-B02_10M"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download TOC-B02_10M GeoTiff"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "TOC-B02_10M"
+                                },
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Quicklook"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access the product quicklook"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "previews",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "category",
+                                    "value": "QUICKLOOK"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "tileId",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "tile_id",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "cloudCover",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "cloud_cover",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "CGS_S1_GRD_L1": {
+        "collection_name": "CGS S1 GRD L1",
+        "collection_description": "S1 datasets processed on VITO premises. Level-1 Single Look Complex (SLC) products consist of focused SAR data, geo-referenced using orbit and attitude data from the satellite, and provided in slant-range geometry. Slant range is the natural radar range observation coordinate, defined as the line-of-sight from the radar to each reflecting object. The products are in zero-Doppler orientation where each row of pixels represents points along a line perpendicular to the sub-satellite track.",
+        "collection_search": "urn:eop:VITO:CGS_S1_GRD_L1",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Ground Range Detected product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download GRD product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "application/zip"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "operationalMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "operational_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationChannels",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_channels",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "CGS_S1_SLC_L1": {
+        "collection_name": "CGS S1 SLC L1",
+        "collection_description": "S1 datasets processed on VITO premises. Level-1 Single Look Complex (SLC) products consist of focused SAR data, geo-referenced using orbit and attitude data from the satellite, and provided in slant-range geometry. Slant range is the natural radar range observation coordinate, defined as the line-of-sight from the radar to each reflecting object. The products are in zero-Doppler orientation where each row of pixels represents points along a line perpendicular to the sub-satellite track.",
+        "collection_search": "urn:eop:VITO:CGS_S1_SLC_L1",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Single Look Complex product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download SLC product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "application/zip"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "operationalMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "operational_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationChannels",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_channels",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "CGS_S1_GRD_SIGMA0_L1": {
+        "collection_name": "CGS S1 GRD SIGMA0 L1",
+        "collection_description": "The Sigma0 product describes how much of the radar signal that was sent out by Sentinel-1 is reflected back to the sensor, and depends on the characteristics of the surface. This product is derived from the L1-GRD product. Typical SAR data processing, which produces level 1 images such as L1-GRD product, does not include radiometric corrections and significant radiometric bias remains. Therefore, it is necessary to apply the radiometric correction to SAR images so that the pixel values of the SAR images truly represent the radar backscatter of the reflecting surface. The radiometric correction is also necessary for the comparison of SAR images acquired with different sensors, or acquired from the same sensor but at different times, in different modes, or processed by different processors. For this Sigma0 product, radiometric calibration was performed using a specific Look Up Table (LUT) that is provided with each original GRD product. This LUT applies a range-dependent gain including the absolute calibration constant, in addition to a constant offset. Next to calibration, also orbit correction, border noise removal, thermal noise removal, and range doppler terrain correction steps were applied during production of Sigma0. The terrain correction step is intended to compensate for distortions due to topographical variations of the scene and the tilt of the satellite sensor, so that the geometric representation of the image will be as close as possible to the real world. The Level1 GRD product can be useful for Land monitoring and Emergency management.",
+        "collection_search": "urn:eop:VITO:CGS_S1_GRD_SIGMA0_L1",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "VH"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "VH"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "VH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "VV"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "VV"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "VV"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "angle"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "angle"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "angle"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "operationalMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "operational_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationChannels",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_channels",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "polarisationMode",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "polarisation_mode",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "TERRASCOPE_SENTINEL_2_LAI_V2": {
+        "collection_name": "Terrascope Sentinel-2 LAI V2",
+        "collection_description": "LAI was defined by Committee of the Earth Observation System (CEOS) as half the developed area of the convex hull wrapping the green canopy elements per unit horizontal ground. This definition allows accounting for elements which are not flat such as needles or stems. LAI is strongly non linearly related to reflectance. Therefore, its estimation from remote sensing observations will be scale dependant over heterogeneous landscapes. When observing a canopy made of different layers of vegetation, it is therefore mandatory to consider all the green layers. This is particularly important for forest canopies where the understory may represent a very significant contribution to the total canopy LAI. The derived LAI corresponds therefore to the total green LAI, including the contribution of the green elements of the understory. The resulting SENTNEL LAI products are relatively consistent with the actual LAI for low LAI values and \u2018non-forest\u2019 surfaces; while for forests, particularly for needle leaf types, significant departures with the True LAI are expected.",
+        "collection_search": "urn:eop:VITO:TERRASCOPE_S2_LAI_V2",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description "
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Leaf Area Index product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download LAI product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Quicklook"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access the product quicklook"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "previews",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "tileId",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "tile_id",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "additionalAttributes",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "resolution",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "resolution",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "cloudCover",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "cloud_cover",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "TERRASCOPE_SENTINEL_2_NDVI_V2": {
+        "collection_name": "Terrascope Sentinel-2 NDVI V2",
+        "collection_description": "The SENTINEL-2 Normalized Difference Vegetation Index (NDVI) is a proxy to quantify the vegetation amount. It is defined as NDVI=(NIR-Red)/(NIR+Red) where NIR corresponds to the reflectance in the near infrared band , and Red to the reflectance in the red band. It is closely related to FAPAR and is little scale dependant.",
+        "collection_search": "urn:eop:VITO:TERRASCOPE_S2_NDVI_V2",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Normalized Difference Vegetation Index product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download NDVI product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Quicklook"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access the product quicklook"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "previews",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "category",
+                                    "value": "QUICKLOOK"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "tileId",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "tile_id",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "additionalAttributes",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "resolution",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "resolution",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "cloudCover",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "cloud_cover",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "TERRASCOPE_SENTINEL_2_FAPAR_V2": {
+        "collection_name": "Terrascope Sentinel-2 FAPAR V2",
+        "collection_description": "FAPAR corresponds to the fraction of photosynthetically active radiation absorbed by the canopy.The FAPAR value results directly from the radiative transfer model in the canopy which is computed instantaneously. It depends on canopy structure, vegetation element optical properties and illumination conditions. FAPAR is very useful as input to a number of primary productivity models which run at the daily time step. Consequently, the product definition should correspond to the daily integrated FAPAR value that can be approached by computation of the clear sky daily integrated FAPAR values as well as the FAPAR value computed for diffuse conditions. The SENTINEL 2 FAPAR product corresponds to the instantaneous black-sky around 10:15 which is a close approximation of the daily integrated black-sky FAPAR value. The FAPAR refers only to the green parts of the canopy.FAPAR corresponds to the fraction of photosynthetically active radiation absorbed by the canopy.The FAPAR value results directly from the radiative transfer model in the canopy which is computed instantaneously. It depends on canopy structure, vegetation element optical properties and illumination conditions. FAPAR is very useful as input to a number of primary productivity models which run at the daily time step. Consequently, the product definition should correspond to the daily integrated FAPAR value that can be approached by computation of the clear sky daily integrated FAPAR values as well as the FAPAR value computed for diffuse conditions. The SENTINEL 2 FAPAR product corresponds to the instantaneous black-sky around 10:15 which is a close approximation of the daily integrated black-sky FAPAR value. The FAPAR refers only to the green parts of the canopy.",
+        "collection_search": "urn:eop:VITO:TERRASCOPE_S2_FAPAR_V2",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Fraction Absorbed Photosynthetically Radiation product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download FAPAR product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Quicklook"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access the product quicklook"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "previews",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "category",
+                                    "value": "QUICKLOOK"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "tileId",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "tile_id",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "additionalAttributes",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "resolution",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "resolution",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "cloudCover",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "cloud_cover",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    },
+    "TERRASCOPE_SENTINEL_2_FCOVER_V2": {
+        "collection_name": "Terrascope Sentinel-2 FCOVER V2",
+        "collection_description": "Fraction of vegetation Cover (FCOVER) corresponds to the gap fraction for nadir direction. It is used to separate vegetation and soil in energy balance processes, including temperature and evapotranspiration. It is computed from the leaf area index and other canopy structural variables and does not depend on variables such as the geometry of illumination as compared to FAPAR. For this reason, it is a very good candidate for the replacement of classical vegetation indices for the monitoring of green vegetation. Because of the linear relationship with radiometric signal, FCOVER will be only marginally scale dependent. Note that similarly to LAI and FAPAR, only the green elements will be considered, either belonging both to the overstorey and understorey.",
+        "collection_search": "urn:eop:VITO:TERRASCOPE_S2_FCOVER_V2",
+        "dataset_tag": {
+            "field_type": "path",
+            "path": [
+                {
+                    "key": "features",
+                    "fixed_attributes": []
+                }
+            ]
+        },
+        "mandatory_fields": {
+            "title": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "identifier": {
+                "field_type": "path",
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "title",
+                        "fixed_attributes": []
+                    }
+                ]
+            },
+            "timerange_start": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "beginningDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "timerange_end": {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "endingDateTime",
+                        "fixed_attributes": []
+                    }
+                ],
+                "parsing_function": "SingleDate"
+            },
+            "spatial": {
+                "path": [
+                    [
+                        {
+                            "key": "geometry",
+                            "fixed_attributes": []
+                        }
+                    ]
+                ],
+                "parsing_function": "GeoJSON"
+            }
+        },
+        "resources": [
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Inspire Metadata"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access to product original metadata description"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "alternates",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "title",
+                                    "value": "Inspire metadata"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Fraction of Vegetation Cover product"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Download FCOVER product"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "data",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "type",
+                                    "value": "image/tiff"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": {
+                    "field_type": "freeText",
+                    "freeText": "Quicklook"
+                },
+                "description": {
+                    "field_type": "freeText",
+                    "freeText": "Access the product quicklook"
+                },
+                "url": {
+                    "field_type": "path",
+                    "path": [
+                        {
+                            "key": "properties",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "links",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "previews",
+                            "fixed_attributes": []
+                        },
+                        {
+                            "key": "href",
+                            "fixed_attributes": [
+                                {
+                                    "key": "category",
+                                    "value": "QUICKLOOK"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "extras": [
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "orbitDirection",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "orbit_direction",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "relativeOrbitNumber",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "relative_orbit_number",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "acquisitionParameters",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "tileId",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "tile_id",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "additionalAttributes",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "resolution",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "resolution",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "cloudCover",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "cloud_cover",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "productInformation",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "processingCenter",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "processing_center",
+                "solr": False
+            },
+            {
+                "path": [
+                    {
+                        "key": "properties",
+                        "fixed_attributes": []
+                    },
+                    {
+                        "key": "status",
+                        "fixed_attributes": []
+                    }
+                ],
+                "field_name": "status",
+                "solr": False
+            }
+        ]
+    }
+}

--- a/ckanext/nextgeossharvest/harvesters/__init__.py
+++ b/ckanext/nextgeossharvest/harvesters/__init__.py
@@ -23,3 +23,4 @@ from ckanext.nextgeossharvest.harvesters.satcen_better import SatcenBetterHarves
 from ckanext.nextgeossharvest.harvesters.noa_groundsegment import NoaGroundsegmentHarvester  # noqa: F401, E501
 from ckanext.nextgeossharvest.harvesters.noa_geobservatory import NoaGeobservatoryHarvester  # noqa: F401, E501
 from ckanext.nextgeossharvest.harvesters.oscar import OSCARHarvester   # noqa: F401, E501
+from ckanext.nextgeossharvest.harvesters.vito import VITO_Harvest  # noqa: F401, E501

--- a/ckanext/nextgeossharvest/harvesters/vito.py
+++ b/ckanext/nextgeossharvest/harvesters/vito.py
@@ -1,0 +1,216 @@
+from ckan.model import Session
+from ckan.model import Package
+from ckan.plugins.core import implements
+from ckanext.harvest.interfaces import IHarvester
+from ckanext.harvest.model import HarvestObject
+from ckanext.harvest.model import HarvestObjectExtra as HOExtra
+from ckanext.nextgeossharvest.lib.nextgeoss_base import NextGEOSSHarvester
+from ckanext.nextgeossharvest.lib.aux_harvest import AuxHarvester
+
+from ckanext.nextgeossharvest.collection_description.vito_collection import COLLECTION
+from ckanext.nextgeossharvest.interfaces.opensearch import OPENSEARCH as INTERFACE
+
+from sqlalchemy import desc
+
+from requests.exceptions import Timeout
+
+import json
+import logging
+import uuid
+
+log = logging.getLogger(__name__)
+
+
+class VITO_Harvest(NextGEOSSHarvester, AuxHarvester):
+    '''
+    A harvester for VITO products.
+    '''
+    implements(IHarvester)
+
+    def info(self):
+        info =  {   'name': 'VITO',
+                    'title': 'VITO Harvester',
+                    'description': 'A Harvester for VITO Products'
+        }
+        return info
+
+    def validate_config(self, config):
+        if not config:
+            return config
+
+        try:
+            INTERFACE.validate_config(config, COLLECTION)
+        except ValueError as e:
+            raise e
+        return config 
+
+    def _get_config(self, harvest_job):
+        return json.loads(harvest_job.source.config)
+    
+    def _get_imported_harvest_objects_by_source(self, source_id):   
+        return Session.query(HarvestObject).filter(
+            HarvestObject.harvest_source_id == source_id,
+            HarvestObject.import_finished is not None)
+
+    def _get_last_harvesting_index(self, source_id, interface):
+        """
+        Return the index of the last product harvested or none
+        if no previous harvesting job
+        """
+        objects = self._get_imported_harvest_objects_by_source(source_id)
+        sorted_objects = objects.order_by(desc(HarvestObject.import_finished))
+        last_object = sorted_objects.limit(1).first()
+        if last_object is not None:
+            index = self._get_object_extra(last_object,
+                                           interface.get_pagination_mechanism(),
+                                           interface.get_minimum_pagination_value())
+            return index
+        else:
+            return None
+
+    # Required by NextGEOSS base harvester
+    def gather_stage(self, harvest_job):
+        self.log = logging.getLogger(__file__)
+        self.log.debug('VITO Harvester gather_stage for job: %r', harvest_job)
+
+        self.job = harvest_job
+        self.source_config = self._get_config(harvest_job)
+        self.update_all = self.source_config.get('update_all', False)
+        interface = INTERFACE(self.source_config, COLLECTION)
+
+        last_product_index = (
+            self._get_last_harvesting_index(harvest_job.source_id, interface)
+        )
+        interface.update_index(last_product_index)
+        interface.build_url()
+        
+        path_to_entries = interface.get_entries_path()
+
+        ids = []
+        try:
+            results = interface.get_results()
+            if results:
+                entries = self.get_field(results, path_to_entries[:])
+            else:
+                return ids
+        except Timeout as e:
+            self._save_gather_error('Request timed out: {}'.format(e), self.job)  # noqa: E501
+            return ids
+        except Exception as e:
+            return ids
+        if entries == None:
+            return ids
+        elif type(entries) is not list:
+            entries = [entries]
+
+        identifier_path = interface.get_identifier_path()
+
+        for entry in entries:
+            entry_id = self.clean_snakecase(self.get_field(entry, identifier_path[:])[0])
+            entry_guid = unicode(uuid.uuid4())
+            package_query = Session.query(Package)
+            query_filtered = package_query.filter(Package.name == entry_id)
+            package = query_filtered.first()
+
+            if package:
+                # Meaning we've previously harvested this,
+                # but we may want to reharvest it now.
+                previous_obj = Session.query(HarvestObject) \
+                    .filter(HarvestObject.guid == entry_guid) \
+                    .filter(HarvestObject.current == True) \
+                    .first()  # noqa: E712
+                if previous_obj:
+                    previous_obj.current = False
+                    previous_obj.save()
+
+                if self.update_all:
+                    log.debug('{} already exists and will be updated.'.format(
+                        entry_id))  # noqa: E501
+                    status = 'change'
+
+                else:
+                    log.debug(
+                        '{} will not be updated.'.format(entry_id))  # noqa: E501
+                    status = 'unchanged'
+
+            elif not package:
+                # It's a product we haven't harvested before.
+                log.debug(
+                    '{} has not been harvested before. Creating a new harvest object.'.  # noqa: E501
+                    format(entry_id))  # noqa: E501
+                status = 'new'
+            obj = HarvestObject(
+                guid=entry_guid,
+                job=self.job,
+                extras=[
+                    HOExtra(key='status', value=status),
+                    HOExtra(key=interface.get_pagination_mechanism(), value=interface.get_index())
+                ])
+            obj.content = json.dumps(entry)
+            obj.package = None if status == 'new' else package
+            obj.save()
+            interface.increment_index()
+            ids.append(obj.id)
+        return ids
+
+
+    def fetch_stage(self, harvest_object):
+        return True
+
+    # Required by NextGEOSS base harvester
+    def _parse_content(self, content):
+        """
+        Parse the entry content and return a dictionary using our standard
+        metadata terms.
+        """
+        content = json.loads(content)
+        interface = INTERFACE(self.source_config, COLLECTION)
+        mandatory_fields = interface.get_mandatory_fields()
+        parsed_content = {}
+        parsed_content.update(interface.get_collection_info())
+        for key, descriptor in mandatory_fields.items():
+            field_value = []
+            if "spatial" == key:
+                for spatial_field in descriptor["path"]:
+                    field_value.extend(self.get_field(content, spatial_field[:]))
+                field_value = self.spatial_parsing(field_value,
+                                                   descriptor["parsing_function"])
+            else:
+                field_value = self.get_field(content, descriptor["path"][:])
+
+                if "timerange_start" in key:
+                    field_value = self.temporal_parsing(field_value[0],
+                                                        descriptor["parsing_function"],
+                                                        0)
+                elif "timerange_start" in key:
+                    field_value = self.temporal_parsing(field_value[0],
+                                                        descriptor["parsing_function"],
+                                                        1)
+                elif "tags" in key:
+                    field_value = self.tag_parsing(field_value)
+                else:
+                    field_value = field_value[0]
+            
+            if field_value:
+                parsed_content[key] = field_value
+        
+        parsed_content["name"] = self.clean_snakecase(parsed_content["identifier"])
+
+        if "notes" not in parsed_content:
+            parsed_content["notes"] = parsed_content["collection_description"]
+
+        if "tags" not in parsed_content:
+            parsed_content["tags"] = []
+
+        resource_fields = interface.get_resource_fields()
+        parsed_content['resource'] = self._parse_resources(content, resource_fields)
+
+        extra_fields = interface.get_extras_fields()
+        parsed_content.update(self._parse_extras(content, extra_fields))
+
+        return parsed_content
+
+    # Required by NextGEOSS base harvester
+    def _get_resources(self, metadata):
+        """Return a list of resource dictionaries."""
+        return metadata['resource']

--- a/ckanext/nextgeossharvest/ignore_list/ignore_list.py
+++ b/ckanext/nextgeossharvest/ignore_list/ignore_list.py
@@ -20,6 +20,7 @@ from meloa import MELOA_IGNORE_DICT
 from satcen_better import SATCEN_BETTER_IGNORE_DICT
 from fsscat import FSSCAT_IGNORE_DICT
 from oscar import OSCAR_IGNORE_DICT
+from vito_ignore_list import VITO_IGNORE_DICT
 
 IGNORE_LIST = {}
 
@@ -45,3 +46,4 @@ IGNORE_LIST.update(MELOA_IGNORE_DICT)
 IGNORE_LIST.update(SATCEN_BETTER_IGNORE_DICT)
 IGNORE_LIST.update(FSSCAT_IGNORE_DICT)
 IGNORE_LIST.update(OSCAR_IGNORE_DICT)
+IGNORE_LIST.update(VITO_IGNORE_DICT)

--- a/ckanext/nextgeossharvest/ignore_list/vito_ignore_list.py
+++ b/ckanext/nextgeossharvest/ignore_list/vito_ignore_list.py
@@ -1,0 +1,27 @@
+SENTINEL_2_TOC_V2_IGNORE_LIST = ['orbit_direction', 'orbit_number', 'relative_orbit_number', 'tile_id', 'cloud_cover', 'processing_center', 'status']
+
+CGS_S1_GRD_L1_IGNORE_LIST = ['operational_mode', 'orbit_direction', 'orbit_number', 'polarisation_channels', 'polarisation_mode', 'relative_orbit_number', 'processing_center', 'status']
+
+CGS_S1_SLC_L1_IGNORE_LIST = ['operational_mode', 'orbit_direction', 'orbit_number', 'polarisation_channels', 'polarisation_mode', 'relative_orbit_number', 'processing_center', 'status']
+
+CGS_S1_GRD_SIGMA0_L1_IGNORE_LIST = ['operational_mode', 'orbit_direction', 'orbit_number', 'polarisation_channels', 'polarisation_mode', 'relative_orbit_number', 'processing_center', 'status']
+
+TERRASCOPE_SENTINEL_2_LAI_V2_IGNORE_LIST = ['orbit_direction', 'relative_orbit_number', 'tile_id', 'resolution', 'cloud_cover', 'processing_center', 'status']
+
+TERRASCOPE_SENTINEL_2_NDVI_V2_IGNORE_LIST = ['orbit_direction', 'relative_orbit_number', 'tile_id', 'resolution', 'cloud_cover', 'processing_center', 'status']
+
+TERRASCOPE_SENTINEL_2_FAPAR_V2_IGNORE_LIST = ['orbit_direction', 'relative_orbit_number', 'tile_id', 'resolution', 'cloud_cover', 'processing_center', 'status']
+
+TERRASCOPE_SENTINEL_2_FCOVER_V2_IGNORE_LIST = ['orbit_direction', 'relative_orbit_number', 'tile_id', 'resolution', 'cloud_cover', 'processing_center', 'status']
+
+
+VITO_IGNORE_DICT = {
+    "SENTINEL_2_TOC_V2": "SENTINEL_2_TOC_V2_IGNORE_LIST",
+    "CGS_S1_GRD_L1": "CGS_S1_GRD_L1_IGNORE_LIST",
+    "CGS_S1_SLC_L1": "CGS_S1_SLC_L1_IGNORE_LIST",
+    "CGS_S1_GRD_SIGMA0_L1": "CGS_S1_GRD_SIGMA0_L1_IGNORE_LIST",
+    "TERRASCOPE_SENTINEL_2_LAI_V2": "TERRASCOPE_SENTINEL_2_LAI_V2_IGNORE_LIST",
+    "TERRASCOPE_SENTINEL_2_NDVI_V2": "TERRASCOPE_SENTINEL_2_NDVI_V2_IGNORE_LIST",
+    "TERRASCOPE_SENTINEL_2_FAPAR_V2": "TERRASCOPE_SENTINEL_2_FAPAR_V2_IGNORE_LIST",
+    "TERRASCOPE_SENTINEL_2_FCOVER_V2": "TERRASCOPE_SENTINEL_2_FCOVER_V2_IGNORE_LIST"
+}

--- a/ckanext/nextgeossharvest/lib/aux_harvest.py
+++ b/ckanext/nextgeossharvest/lib/aux_harvest.py
@@ -1,0 +1,172 @@
+import json
+import codecs
+import stringcase
+import numbers
+import shapely.wkt
+import shapely.geometry
+import datetime
+import re
+
+from dateutil.parser import parse
+# from pyproj import Transformer
+
+class AuxHarvester():
+    def clean_snakecase(self, og_string):
+        og_string = re.sub('[^0-9a-zA-Z]+', '_', og_string).lower()
+        sc_string = stringcase.snakecase(og_string).strip("_")
+        while "__" in sc_string:
+            sc_string = sc_string.replace("__", "_")
+        return sc_string
+
+    def check_attributes(self, json_dict, fixed_attributes):
+        for fixed_attribute in fixed_attributes:
+            attribute_key = fixed_attribute["key"]
+            attribute_value = fixed_attribute["value"]
+            actual_value = json_dict.get(attribute_key, None)
+            if not actual_value or attribute_value != actual_value:
+                return None
+        return True
+
+    def get_field(self, json_dict, field_path):
+        result = []
+        if len(field_path) == 0:
+            return [json_dict]
+        else:
+            tag = field_path.pop(0)
+            if tag["key"] not in json_dict:
+                return None
+            elif self.check_attributes(json_dict, tag["fixed_attributes"]):
+                new_json_dict = json_dict[tag["key"]]
+                if type(new_json_dict) is list:
+                    for list_entry in new_json_dict:
+                        # Python3
+                        #value = self.get_field(list_entry, field_path.copy())
+                        # Python2
+                        value = self.get_field(list_entry, field_path[:])
+                        if value:
+                            result.extend(value)
+                else:
+                    # Python3
+                    #value = self.get_field(new_json_dict, field_path.copy())
+                    # Python3
+                    value = self.get_field(new_json_dict, field_path[:])
+                    if value:
+                        result.extend(value)
+                return result
+            else:
+                return None
+
+    def _parse_resources(self, content, resource_fields):
+        resources = []
+        for resource in resource_fields:
+            single_resource = {}
+            for key, field in resource.items():
+                if field["field_type"] == "freeText":
+                    single_resource[key] = field["freeText"]
+                elif field["field_type"] == "path":
+                    field_value = self.get_field(content, field["path"][:])
+                    if field_value:
+                        single_resource[key] = field_value[0]
+                    else:
+                        break
+            resources.append(single_resource)
+        return resources
+
+    def _parse_extras(self, content, extra_fields):
+        extras = {}
+        for extra in extra_fields:
+            field_name = self.clean_snakecase(extra["field_name"])
+            field_value = self.get_field(content, extra["path"][:])
+            if field_value:
+                extras.update({field_name: field_value[0]})
+        return extras
+
+    def tag_parsing(self, tag_list):
+        ckan_tag_list = []
+        for tag in tag_list:
+            str_tag = str(tag)
+            if len(str_tag)<=3 and len(str_tag)>0:
+                ckan_tag_list.append({"name": str(tag)})
+        return ckan_tag_list
+
+    def temporal_parsing(self, date, parsing_function, end=0):
+        start_default = datetime.datetime(2020,1,1,0,0,0)
+        end_default = datetime.datetime(2020,12,31,23,59,59)
+        default_date = end_default if end else start_default
+
+        if parsing_function == "SingleDate":
+            return parse(date, default=default_date).strftime("%Y-%m-%dT%H:%M:%SZ")
+        elif parsing_function == "SlashDate":
+            start_date, end_date = date.split("/")
+            start_date = parse(start_date, default=default_date).strftime("%Y-%m-%dT%H:%M:%SZ")
+            end_date = parse(end_date, default=default_date).strftime("%Y-%m-%dT%H:%M:%SZ")
+            return end_date if end else start_date
+        else:
+            raise ModuleNotFoundError("{} is not a recognized date parsing function".format(parsing_function))
+
+
+    def spatial_parsing(self, spatial, parsing_function):
+        if spatial:
+            geojson = None
+            if parsing_function == "GeoJSON":
+                geojson = spatial[0]
+
+            elif parsing_function == "WKT":
+                shapely_wkt = shapely.wkt.loads(spatial[0])
+                geojson = shapely.geometry.mapping(shapely_wkt)
+
+            elif parsing_function == "CardinalPoints":
+                lon1, lat1, lon2, lat2 = spatial
+                geojson = self.bbcoords2geometry(float(lon1),float(lat1),
+                                               float(lon2),float(lat2))
+
+            elif parsing_function == "BboxDiffTagSpace":
+                lon1, lat1 = spatial[0].split(" ")
+                lon2, lat2 = spatial[1].split(" ")
+                geojson = self.bbcoords2geometry(float(lon1),float(lat1),
+                                               float(lon2),float(lat2))
+            else:
+                raise ModuleNotFoundError("{} is not a recognized spatial parsing function".format(parsing_function))
+            return json.dumps(geojson)
+
+    def bbcoords2geometry(self, min_long, min_lat, max_long, max_lat):
+        shapely_polygon = shapely.geometry.Polygon([(min_long, min_lat),
+                                                    (min_long, max_lat),
+                                                    (max_long, max_lat),
+                                                    (max_long, min_lat)])
+                                                    
+        return json.loads(json.dumps(shapely.geometry.mapping(shapely_polygon)))
+
+"""
+    # Current version of pyproj does not have the property Transformer, in order
+    # to upgrade the version, it is also required to upgrade the version of 
+    # PROJ (OS package), which breaks other python libraries
+    # NOTE: This only happens due to the fact that python2 is deprecated
+    def project_coords(self, coords, from_proj, to_proj):
+        if len(coords) < 1:
+            return []
+
+        if isinstance(coords[0], numbers.Number):
+            transformer = Transformer.from_crs(from_proj, to_proj)
+            from_x, from_y = coords
+            # There is a known issue where with the new syntax
+            # ("EPSG:4326"), PROJ honors the axis order of the CRS
+            # definition (which is lat, lon), while before it assumed
+            # an x, y (so lon, lat) order.
+            to_x, to_y = transformer.transform(from_x, from_y)
+            return [to_y, to_x]
+
+        new_coords = []
+        for coord in coords:
+            new_coords.append(self.project_coords(coord, from_proj, to_proj))
+        return new_coords
+    
+    def project_geometry(self, geometry, from_proj, to_proj):
+        if 'coordinates' not in geometry:
+            print('Failed project feature')
+            return None
+
+        new_coordinates = self.project_coords(geometry['coordinates'], from_proj, to_proj)
+        geometry['coordinates'] = new_coordinates
+        return geometry
+"""

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         noa_groundsegment=ckanext.nextgeossharvest.harvesters:NoaGroundsegmentHarvester
         noa_geobservatory=ckanext.nextgeossharvest.harvesters:NoaGeobservatoryHarvester
         oscar=ckanext.nextgeossharvest.harvesters:OSCARHarvester
+        vito=ckanext.nextgeossharvest.harvesters:VITO_Harvest
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
### Features:
Add new harvester to catalogue VITO products exposed via OpenSearch.

8 new collections were added.

Harvester configuration is as follows:
{
    "base_query_url": "https://services.terrascope.be/catalogue/products?collection=urn:eop:VITO:TERRASCOPE_S2_FAPAR_V2",
    "page_size_keyword": "count",
    "page_start_keyword": "startIndex",
    "collection_keyword": "collection",
    "max_dataset": 100,
    "update_all": true,
    "collection": ""
}

List of Collections IDS to be used in the harvest configuration:
-    "SENTINEL_2_TOC_V2",
-    "CGS_S1_GRD_L1",
-    "CGS_S1_SLC_L1",
-    "CGS_S1_GRD_SIGMA0_L1",
-    "TERRASCOPE_SENTINEL_2_LAI_V2",
-    "TERRASCOPE_SENTINEL_2_NDVI_V2",
-    "TERRASCOPE_SENTINEL_2_FAPAR_V2",
-    "TERRASCOPE_SENTINEL_2_FCOVER_V2"


- [ ] includes new  features
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes bugfix

Please [X] all the boxes above that apply
